### PR TITLE
fix: upgrade package to use Scala 2.12 and Spark 3.1.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -84,9 +84,9 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
   <properties>
     <project.build.sourceEncoding>
     UTF-8</project.build.sourceEncoding>
-    <scala.version>2.11.12</scala.version>
-    <scala.binary.version>2.11</scala.binary.version>
-    <spark.version>2.4.4</spark.version>
+    <scala.version>2.12.0</scala.version>
+    <scala.binary.version>2.12</scala.binary.version>
+    <spark.version>3.1.2</spark.version>
     <java.version>1.8</java.version>
   </properties>
   <dependencies>
@@ -159,7 +159,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
     <dependency>
       <groupId>org.scalatest</groupId>
       <artifactId>scalatest_${scala.binary.version}</artifactId>
-      <version>2.2.6</version>
+      <version>3.2.10</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/src/test/scala/com/aamend/spark/gdelt/ContentFetcherTest.scala
+++ b/src/test/scala/com/aamend/spark/gdelt/ContentFetcherTest.scala
@@ -1,9 +1,11 @@
 package com.aamend.spark.gdelt
 
 import org.apache.spark.ml.Pipeline
-import org.scalatest.Matchers
+import org.scalatest._
+import flatspec._
+import matchers._
 
-class ContentFetcherTest extends SparkSpec with Matchers {
+class ContentFetcherTest extends SparkSpec with should.Matchers {
 
   sparkTest("testing E2E pipeline") { spark =>
 

--- a/src/test/scala/com/aamend/spark/gdelt/GdeltParserTest.scala
+++ b/src/test/scala/com/aamend/spark/gdelt/GdeltParserTest.scala
@@ -1,10 +1,12 @@
 package com.aamend.spark.gdelt
 
-import org.scalatest.Matchers
+import org.scalatest._
+import flatspec._
+import matchers._
 
 import scala.io.Source
 
-class GdeltParserTest extends SparkSpec with Matchers {
+class GdeltParserTest extends SparkSpec with should.Matchers {
 
   //   I simply test all my dataframes can be loaded, no exception should be thrown
   sparkTest("loading GDELT universe") { spark =>

--- a/src/test/scala/com/aamend/spark/gdelt/SparkSpec.scala
+++ b/src/test/scala/com/aamend/spark/gdelt/SparkSpec.scala
@@ -2,9 +2,9 @@ package com.aamend.spark.gdelt
 
 import org.apache.log4j.{Level, Logger}
 import org.apache.spark.sql.SparkSession
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 
-trait SparkSpec extends FunSuite {
+trait SparkSpec extends AnyFunSuite {
 
   Logger.getLogger("org").setLevel(Level.OFF)
   Logger.getLogger("akka").setLevel(Level.OFF)

--- a/src/test/scala/com/aamend/spark/gdelt/TTest.scala
+++ b/src/test/scala/com/aamend/spark/gdelt/TTest.scala
@@ -1,8 +1,10 @@
 package com.aamend.spark.gdelt
 
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest._
+import flatspec._
+import matchers._
 
-class TTest extends FlatSpec with Matchers {
+class TTest extends AnyFlatSpec with should.Matchers {
 
   "null" should "return None" in {
     T(()=>null) should be(None)


### PR DESCRIPTION
Updated dependencies and tests.
Tested the package on `csv` files from GDELT and it works.

Might have imported libraries that are not needed in the unit tests but that can be tended to if needed.